### PR TITLE
chore(release): promote v0.1.1

### DIFF
--- a/.github/workflows/release-test.yml
+++ b/.github/workflows/release-test.yml
@@ -34,7 +34,7 @@ jobs:
 
     steps:
       - name: Check out target ref
-        uses: actions/checkout@v5
+        uses: actions/checkout@v6
         with:
           ref: ${{ inputs.target_ref }}
           fetch-depth: 0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
     outputs:
       semver: ${{ steps.parse.outputs.semver }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           ref: ${{ inputs.target_ref }}
       - name: Validate and parse version
@@ -71,7 +71,7 @@ jobs:
             target: aarch64-apple-darwin
     runs-on: ${{ matrix.runner }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           ref: ${{ inputs.target_ref }}
       - name: Install Rust
@@ -102,7 +102,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [validate-version, create-release]
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           ref: ${{ inputs.target_ref }}
           fetch-depth: 0
@@ -126,7 +126,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: validate-version
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           ref: ${{ inputs.target_ref }}
       - name: Generate release notes

--- a/packaging/homebrew/makevn.rb
+++ b/packaging/homebrew/makevn.rb
@@ -6,39 +6,19 @@ class Makevn < Formula
   homepage "https://github.com/antonillos/makevn"
   license "MIT"
 
-  head "https://github.com/antonillos/makevn.git", branch: "main"
-
-  stable do
-    url "https://github.com/antonillos/makevn/releases/download/v0.1.0/makevn-v0.1.0.tar.gz"
-    sha256 "TBD_AFTER_RELEASE"
+  if Hardware::CPU.arm?
+    url "https://github.com/antonillos/makevn/releases/download/v0.1.0/makevn-v0.1.0-aarch64-apple-darwin.tar.gz"
+    sha256 "d4199327615da6e793846e4527711a5317e3804767b3515bad29a4fd602db888"
+  else
+    url "https://github.com/antonillos/makevn/releases/download/v0.1.0/makevn-v0.1.0-x86_64-apple-darwin.tar.gz"
+    sha256 "4a60fd6cb689db774c1ed1ef7a4e0c09b578af847d9eddb3a15601ad304c060d"
   end
 
-  depends_on "rust" => :build
-
   def install
-    if build.head?
-      system "./build-rust-dispatcher.sh"
-    else
-      system "cargo", "build", "--release", "--manifest-path", "rust/dispatcher/Cargo.toml"
-    end
-
-    bin.install "target/release/makevn"
-    bin.install "target/release/makevn-mcp"
-
-    (libexec/"makevn").install Dir[
-      "libexec/makevn/backend.sh",
-      "libexec/makevn/cli.sh",
-      "libexec/makevn/common.sh",
-      "libexec/makevn/commands",
-      "libexec/makevn/common",
-      "libexec/makevn/coverage",
-      "libexec/makevn/docker",
-      "libexec/makevn/jdk",
-      "libexec/makevn/compat",
-    ]
-
-    (share/"makevn").install Dir["share/makevn/*"]
-    (share/"makevn/skills/makevn").install Dir["skills/makevn/*"]
+    bin.install "bin/makevn"
+    bin.install "bin/makevn-mcp"
+    libexec.install "libexec/makevn"
+    share.install "share/makevn"
   end
 
   def caveats

--- a/rust/dispatcher/Cargo.lock
+++ b/rust/dispatcher/Cargo.lock
@@ -103,9 +103,9 @@ dependencies = [
 
 [[package]]
 name = "signal-hook"
-version = "0.3.18"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
+checksum = "b2a0c28ca5908dbdbcd52e6fdaa00358ab88637f8ab33e1f188dd510eb44b53d"
 dependencies = [
  "libc",
  "signal-hook-registry",

--- a/rust/dispatcher/Cargo.lock
+++ b/rust/dispatcher/Cargo.lock
@@ -26,7 +26,7 @@ checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "makevn-dispatcher"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "libc",
  "serde",

--- a/rust/dispatcher/Cargo.lock
+++ b/rust/dispatcher/Cargo.lock
@@ -90,9 +90,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.149"
+version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
  "itoa",
  "memchr",

--- a/rust/dispatcher/Cargo.toml
+++ b/rust/dispatcher/Cargo.toml
@@ -14,6 +14,6 @@ path = "src/main.rs"
 
 [dependencies]
 libc = "0.2"
-signal-hook = "0.3"
+signal-hook = "0.4"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/rust/dispatcher/Cargo.toml
+++ b/rust/dispatcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "makevn-dispatcher"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 publish = false
 

--- a/rust/dispatcher/src/main.rs
+++ b/rust/dispatcher/src/main.rs
@@ -30,6 +30,18 @@ fn main() {
         .and_then(|name| name.to_str())
         .is_some_and(|name| name == "makevn-mcp")
     {
+        match parse_mcp_invocation(env::args_os().skip(1).collect()) {
+            Ok(McpAction::PrintHelp) => {
+                print_mcp_help();
+                return;
+            }
+            Ok(McpAction::PrintVersion) => {
+                println!("{}", makevn_version());
+                return;
+            }
+            Ok(McpAction::RunServer) => {}
+            Err(message) => exit_with_error(message),
+        }
         let current_exe = match env::current_exe() {
             Ok(path) => path,
             Err(error) => exit_with_error(format!("failed to resolve current executable: {error}")),
@@ -122,6 +134,13 @@ enum Action {
     PrintCommandHelp { command: String },
     DispatchToBackend(Vec<BackendInvocation>),
     RunMcpServer,
+}
+
+#[derive(Debug, Eq, PartialEq)]
+enum McpAction {
+    PrintHelp,
+    PrintVersion,
+    RunServer,
 }
 
 #[derive(Debug, Eq, PartialEq)]
@@ -295,6 +314,23 @@ fn parse_invocation(args: Vec<OsString>) -> Result<Action, String> {
         global_compact,
     )?;
     Ok(Action::DispatchToBackend(backend_invocations))
+}
+
+fn parse_mcp_invocation(args: Vec<OsString>) -> Result<McpAction, String> {
+    match args.as_slice() {
+        [] => Ok(McpAction::RunServer),
+        [arg] if matches!(arg.to_string_lossy().as_ref(), "--help" | "-h") => {
+            Ok(McpAction::PrintHelp)
+        }
+        [arg] if arg == &OsString::from("--version") => Ok(McpAction::PrintVersion),
+        [arg] => Err(format!(
+            "Unknown makevn-mcp option: {}\nRun `makevn-mcp --help` for usage.",
+            Lossy(arg)
+        )),
+        _ => Err(String::from(
+            "makevn-mcp does not accept positional arguments. Run `makevn-mcp --help` for usage.",
+        )),
+    }
 }
 
 fn split_command_segments(args: Vec<OsString>) -> Result<Vec<(OsString, Vec<OsString>)>, String> {
@@ -3148,6 +3184,19 @@ fn print_help(with_header: bool) {
     println!("  - 'makevn-mcp' starts the MCP server over stdio (Model Context Protocol).");
 }
 
+fn print_mcp_help() {
+    println!("makevn-mcp {}", makevn_version());
+    println!();
+    println!("Model Context Protocol server for makevn.");
+    println!();
+    println!("Usage:");
+    println!("  makevn-mcp");
+    println!("  makevn-mcp --help");
+    println!("  makevn-mcp --version");
+    println!();
+    println!("Run without arguments from an MCP client. The server communicates over stdio.");
+}
+
 struct Lossy<'a>(&'a OsString);
 
 impl fmt::Display for Lossy<'_> {
@@ -3161,9 +3210,9 @@ mod tests {
     use super::{
         command_help, command_supports_frontend_loader, dashboard_hint, dim_text,
         format_resource_sample, insert_backend_option, install_root_with_override,
-        parse_invocation, read_backend_metadata, spinner_hint, spinner_kitt_frame,
+        parse_invocation, parse_mcp_invocation, read_backend_metadata, spinner_hint, spinner_kitt_frame,
         split_command_segments, strip_frontend_tail_flag, tail_status_lines, Action,
-        BackendInvocation, BackendMetadata, CommandSummary, ResourceHistory, ResourceSample,
+        BackendInvocation, BackendMetadata, CommandSummary, McpAction, ResourceHistory, ResourceSample,
     };
     use std::env;
     use std::ffi::OsString;
@@ -3203,6 +3252,30 @@ mod tests {
     fn preserves_global_help_dispatch() {
         let action = parse_invocation(vec![OsString::from("--help")]).unwrap();
         assert_eq!(action, Action::PrintHelp { with_header: false });
+    }
+
+    #[test]
+    fn parses_mcp_help_without_starting_server() {
+        let action = parse_mcp_invocation(vec![OsString::from("--help")]).unwrap();
+        assert_eq!(action, McpAction::PrintHelp);
+    }
+
+    #[test]
+    fn parses_mcp_version_without_starting_server() {
+        let action = parse_mcp_invocation(vec![OsString::from("--version")]).unwrap();
+        assert_eq!(action, McpAction::PrintVersion);
+    }
+
+    #[test]
+    fn parses_mcp_no_args_as_server() {
+        let action = parse_mcp_invocation(Vec::new()).unwrap();
+        assert_eq!(action, McpAction::RunServer);
+    }
+
+    #[test]
+    fn rejects_mcp_positional_args() {
+        let error = parse_mcp_invocation(vec![OsString::from("doctor")]).unwrap_err();
+        assert!(error.contains("Unknown makevn-mcp option"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- promote MCP help fix to main
- prepare v0.1.1 release

## Validation
- cargo test --manifest-path rust/dispatcher/Cargo.toml
- ./build-rust-dispatcher.sh
- target/release/makevn-mcp --help
- target/release/makevn-mcp --version