### PR TITLE
docs(asdf): support modern set command

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -149,7 +149,8 @@ jobs:
           ```bash
           asdf plugin add makevn https://github.com/antonillos/asdf-makevn.git
           asdf install makevn latest
-          asdf global makevn latest
+          MAKEVN_VERSION="$(asdf latest makevn | sed -n '$p')"
+          asdf set -u makevn "${MAKEVN_VERSION}"
           ```
 
           Fallback installer:

--- a/README.md
+++ b/README.md
@@ -48,7 +48,8 @@ Recommended for WSL2 and Linux workstations managed with asdf:
 ```bash
 asdf plugin add makevn https://github.com/antonillos/asdf-makevn.git
 asdf install makevn latest
-asdf global makevn latest
+MAKEVN_VERSION="$(asdf latest makevn | sed -n '$p')"
+asdf set -u makevn "${MAKEVN_VERSION}"
 ```
 
 ### Agent fallback install

--- a/docs/agent-install.md
+++ b/docs/agent-install.md
@@ -30,10 +30,19 @@ fi
 Install or upgrade:
 
 ```bash
-asdf plugin add makevn https://github.com/antonillos/asdf-makevn.git || asdf plugin update makevn
-asdf install makevn latest
-asdf global makevn latest
+if asdf plugin list | grep -qx makevn; then
+  asdf plugin update makevn
+else
+  asdf plugin add makevn https://github.com/antonillos/asdf-makevn.git
+fi
+
+MAKEVN_VERSION="$(asdf latest makevn | sed -n '$p')"
+asdf install makevn "${MAKEVN_VERSION}"
+asdf set -u makevn "${MAKEVN_VERSION}"
+asdf reshim makevn "${MAKEVN_VERSION}"
 ```
+
+`asdf` 0.16+ uses `asdf set -u` instead of the legacy `asdf global` command.
 
 ## Fallback Installer
 

--- a/docs/distribution.md
+++ b/docs/distribution.md
@@ -80,7 +80,8 @@ Install command:
 ```bash
 asdf plugin add makevn https://github.com/antonillos/asdf-makevn.git
 asdf install makevn latest
-asdf global makevn latest
+MAKEVN_VERSION="$(asdf latest makevn | sed -n '$p')"
+asdf set -u makevn "${MAKEVN_VERSION}"
 ```
 
 The plugin downloads a runtime archive from GitHub Releases, verifies its

--- a/docs/install.md
+++ b/docs/install.md
@@ -37,7 +37,8 @@ brew upgrade antonillos/tap/makevn
 ```bash
 asdf plugin add makevn https://github.com/antonillos/asdf-makevn.git
 asdf install makevn latest
-asdf global makevn latest
+MAKEVN_VERSION="$(asdf latest makevn | sed -n '$p')"
+asdf set -u makevn "${MAKEVN_VERSION}"
 ```
 
 Upgrade with:
@@ -45,7 +46,8 @@ Upgrade with:
 ```bash
 asdf plugin update makevn
 asdf install makevn latest
-asdf global makevn latest
+MAKEVN_VERSION="$(asdf latest makevn | sed -n '$p')"
+asdf set -u makevn "${MAKEVN_VERSION}"
 ```
 
 ## Agent Fallback Installer

--- a/packaging/asdf/bin/latest-stable
+++ b/packaging/asdf/bin/latest-stable
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+plugin_dir="$(CDPATH= cd -- "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+"${plugin_dir}/bin/list-all" | sed -n '$p'


### PR DESCRIPTION
## Summary
- replace legacy asdf global examples with asdf set -u
- make the agent install command robust when the plugin already exists
- add latest-stable to the packaged asdf plugin and publish the live plugin fix

## Validation
- bash -n packaging/asdf/bin/latest-stable
- ruby YAML parse for .github/workflows/release.yml
- git diff --check
- asdf plugin update makevn
- asdf latest makevn