### PR TITLE
release: bump to 0.1.3

### DIFF
--- a/packaging/homebrew/makevn.rb
+++ b/packaging/homebrew/makevn.rb
@@ -6,13 +6,8 @@ class Makevn < Formula
   homepage "https://github.com/antonillos/makevn"
   license "MIT"
 
-  if Hardware::CPU.arm?
-    url "https://github.com/antonillos/makevn/releases/download/v0.1.3/makevn-v0.1.3.tar.gz"
-    sha256 "TBD_AFTER_RELEASE"
-  else
-    url "https://github.com/antonillos/makevn/releases/download/v0.1.3/makevn-v0.1.3.tar.gz"
-    sha256 "TBD_AFTER_RELEASE"
-  end
+  url "https://github.com/antonillos/makevn/releases/download/v0.1.3/makevn-v0.1.3.tar.gz"
+  sha256 "a129067b7020612ce684fbc4a8613148715dd930ed1c225c58bbec864054d2b4"
 
   def install
     bin.install "bin/makevn"

--- a/packaging/homebrew/makevn.rb
+++ b/packaging/homebrew/makevn.rb
@@ -7,11 +7,11 @@ class Makevn < Formula
   license "MIT"
 
   if Hardware::CPU.arm?
-    url "https://github.com/antonillos/makevn/releases/download/v0.1.0/makevn-v0.1.0-aarch64-apple-darwin.tar.gz"
-    sha256 "d4199327615da6e793846e4527711a5317e3804767b3515bad29a4fd602db888"
+    url "https://github.com/antonillos/makevn/releases/download/v0.1.3/makevn-v0.1.3.tar.gz"
+    sha256 "TBD_AFTER_RELEASE"
   else
-    url "https://github.com/antonillos/makevn/releases/download/v0.1.0/makevn-v0.1.0-x86_64-apple-darwin.tar.gz"
-    sha256 "4a60fd6cb689db774c1ed1ef7a4e0c09b578af847d9eddb3a15601ad304c060d"
+    url "https://github.com/antonillos/makevn/releases/download/v0.1.3/makevn-v0.1.3.tar.gz"
+    sha256 "TBD_AFTER_RELEASE"
   end
 
   def install

--- a/rust/dispatcher/Cargo.toml
+++ b/rust/dispatcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "makevn-dispatcher"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 publish = false
 


### PR DESCRIPTION
## Summary
- bump dispatcher version to 0.1.3
- update packaged Homebrew formula URL placeholder for v0.1.3

## Release
- tag v0.1.3 has been pushed for the release workflow
- formula SHA remains TBD until release assets are available