### PR TITLE
docs: add community standards

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,35 @@
+---
+name: Bug report
+about: Report something that is not working as expected
+title: ""
+labels: bug
+assignees: ""
+---
+
+## What Happened
+
+Describe the bug and what you expected to happen.
+
+## Reproduction Steps
+
+1. 
+2. 
+3. 
+
+## Environment
+
+- OS:
+- Shell:
+- makevn version:
+- Java version:
+- Maven version:
+
+## Logs or Output
+
+```text
+
+```
+
+## Additional Context
+
+Add any other context that may help diagnose the issue.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Security vulnerability
+    url: https://github.com/antonillos/makevn/security/policy
+    about: Please report suspected vulnerabilities privately through the security policy.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,23 @@
+---
+name: Feature request
+about: Suggest an improvement or new capability
+title: ""
+labels: enhancement
+assignees: ""
+---
+
+## Problem
+
+Describe the problem or workflow gap this would solve.
+
+## Proposed Solution
+
+Describe the behavior you would like makevn to support.
+
+## Alternatives Considered
+
+Describe any workarounds or alternatives you have considered.
+
+## Additional Context
+
+Add examples, command output, or links that may help explain the request.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,13 @@
+## Summary
+
+- 
+
+## Verification
+
+- [ ] I ran the relevant local checks
+- [ ] I updated documentation for user-facing changes
+- [ ] This change does not include secrets, generated artifacts, or unrelated cleanup
+
+## Notes
+
+- 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,35 @@
+# Code of Conduct
+
+## Our Pledge
+
+We pledge to make participation in this project a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment include:
+
+- using welcoming and inclusive language
+- being respectful of differing viewpoints and experiences
+- accepting constructive feedback gracefully
+- focusing on what is best for the project and its users
+- showing empathy toward other community members
+
+Examples of unacceptable behavior include:
+
+- harassment, intimidation, or discrimination in any form
+- trolling, insulting or derogatory comments, and personal attacks
+- publishing others' private information without explicit permission
+- unwelcome sexual attention or advances
+- other conduct that could reasonably be considered inappropriate in a professional setting
+
+## Enforcement
+
+Project maintainers are responsible for clarifying and enforcing standards of acceptable behavior. Maintainers may remove, edit, or reject comments, commits, code, issues, pull requests, and other contributions that are not aligned with this Code of Conduct.
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported privately to the repository owner. All complaints will be reviewed and investigated promptly and fairly.
+
+Maintainers may take any action they deem appropriate, including a warning, temporary ban, or permanent ban from project spaces.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org/), version 2.1.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,57 @@
+# Contributing
+
+Thanks for your interest in contributing to makevn.
+
+makevn provides a stable terminal-first command surface for Java Maven repositories. Changes should keep the tool predictable for both humans and AI agents.
+
+## Before You Start
+
+- Check existing issues and pull requests to avoid duplicate work.
+- Open an issue first for large behavior changes, new commands, or changes that affect installation and release flows.
+- Keep changes focused and avoid unrelated cleanup in the same pull request.
+
+## Development Setup
+
+For local development from this repository:
+
+```bash
+./build-rust-dispatcher.sh
+./install.sh --rust
+~/.local/bin/makevn --help
+```
+
+The Rust dispatcher lives under `rust/dispatcher`. Shell command behavior lives under `libexec/makevn/`.
+
+## Testing
+
+Run the smallest relevant check for your change before opening a pull request.
+
+Useful commands include:
+
+```bash
+./build-rust-dispatcher.sh
+cargo test --manifest-path rust/dispatcher/Cargo.toml
+test/sanitize/run.sh
+test/repo-sweep/run.sh
+```
+
+For changes affecting release packaging, also review the scripts under `packaging/release/` and the release workflows under `.github/workflows/`.
+
+## Pull Requests
+
+- Describe what changed and why.
+- Include verification steps and results.
+- Update documentation when user-facing behavior changes.
+- Keep compatibility in mind for existing installed versions and package managers.
+- Do not include secrets, local machine paths, or generated build artifacts unless explicitly required.
+
+## Code Style
+
+- Use English for code, comments, and documentation.
+- Prefer small, direct changes over broad refactors.
+- Keep shell scripts portable and defensive.
+- Preserve existing command names, output contracts, and non-interactive behavior unless the change intentionally updates them.
+
+## Security
+
+Do not report suspected vulnerabilities in public issues. Follow the instructions in [SECURITY.md](SECURITY.md).


### PR DESCRIPTION
## Summary
- add code of conduct and contributing guide
- add issue templates for bugs and feature requests
- add pull request template and security contact link

## Verification
- not run; documentation and GitHub metadata only