### PR TITLE
release: bump to 0.1.4

### DIFF
--- a/rust/dispatcher/Cargo.lock
+++ b/rust/dispatcher/Cargo.lock
@@ -26,7 +26,7 @@ checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "makevn-dispatcher"
-version = "0.1.2"
+version = "0.1.4"
 dependencies = [
  "libc",
  "serde",

--- a/rust/dispatcher/Cargo.toml
+++ b/rust/dispatcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "makevn-dispatcher"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2021"
 publish = false
 


### PR DESCRIPTION
## What
Bump makevn to 0.1.4 so the release workflow can publish v0.1.4 from main.

## How
- **Version metadata** — updates the Rust dispatcher manifest and lockfile version from 0.1.3 to 0.1.4 so the release workflow validation accepts `v0.1.4`.

## Verification
- cargo test --manifest-path rust/dispatcher/Cargo.toml