### PR TITLE
chore: update homebrew formula to v0.1.5

### DIFF
--- a/packaging/homebrew/makevn.rb
+++ b/packaging/homebrew/makevn.rb
@@ -7,11 +7,11 @@ class Makevn < Formula
   license "MIT"
 
   if Hardware::CPU.arm?
-    url "https://github.com/antonillos/makevn/releases/download/v0.1.3/makevn-v0.1.3-aarch64-apple-darwin.tar.gz"
-    sha256 "2a3b68f065f4fd3fcce9a5a8886bea7dd7696a27c073bdb8fccf0ceea04cd69f"
+    url "https://github.com/antonillos/makevn/releases/download/v0.1.5/makevn-v0.1.5-aarch64-apple-darwin.tar.gz"
+    sha256 "fc56901660cc15cb35399060849ef7437dafe378356b2fc53bc2cdeba1e3ffc8"
   else
-    url "https://github.com/antonillos/makevn/releases/download/v0.1.3/makevn-v0.1.3-x86_64-apple-darwin.tar.gz"
-    sha256 "71de52964fc21e96c6d7b283a53c28ecafb697a99e96b59376dabdfffbe07d2b"
+    url "https://github.com/antonillos/makevn/releases/download/v0.1.5/makevn-v0.1.5-x86_64-apple-darwin.tar.gz"
+    sha256 "d6eb6a9d36ccb49c0adcc85dd343acc8048fc6761f773cce32baa3a95e12ac9c"
   end
 
   def install


### PR DESCRIPTION
Updates the Homebrew formula references from v0.1.3 to v0.1.5 with new SHA256 hashes for both aarch64 and x86_64 macOS binaries.