### PR TITLE
chore: sync release 0.1.9 into develop

### DIFF
--- a/rust/dispatcher/Cargo.lock
+++ b/rust/dispatcher/Cargo.lock
@@ -26,7 +26,7 @@ checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "makevn-dispatcher"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "libc",
  "serde",

--- a/rust/dispatcher/Cargo.toml
+++ b/rust/dispatcher/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "makevn-dispatcher"
-version = "0.1.8"
+version = "0.1.9"
 edition = "2021"
 publish = false
 


### PR DESCRIPTION
Sync the v0.1.9 release version bump back into develop.